### PR TITLE
noserver for 'mvn gwt:run -Pdev'

### DIFF
--- a/modular-requestfactory/src/main/resources/archetype-resources/client/pom.xml
+++ b/modular-requestfactory/src/main/resources/archetype-resources/client/pom.xml
@@ -152,7 +152,7 @@
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>gwt-maven-plugin</artifactId>
 						<configuration>
-							<webappDirectory>${dollar}{basedir}/../server/target/${rootArtifactId}-server-${dollar}{project.version}/</webappDirectory>
+							<noServer>true</noServer>
 							<runTarget>http://localhost:8080/${rootArtifactId}-server-${dollar}{project.version}/</runTarget>
 						</configuration>
 					</plugin>

--- a/modular-requestfactory/src/test/resources/projects/basic/reference/client/pom.xml
+++ b/modular-requestfactory/src/test/resources/projects/basic/reference/client/pom.xml
@@ -151,7 +151,7 @@
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>gwt-maven-plugin</artifactId>
 						<configuration>
-							<webappDirectory>${basedir}/../server/target/basic-server-${project.version}/</webappDirectory>
+							<noServer>true</noServer>
 							<runTarget>http://localhost:8080/basic-server-${project.version}/</runTarget>
 						</configuration>
 					</plugin>

--- a/modular-webapp/src/main/resources/archetype-resources/client/pom.xml
+++ b/modular-webapp/src/main/resources/archetype-resources/client/pom.xml
@@ -152,6 +152,7 @@
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>gwt-maven-plugin</artifactId>
 						<configuration>
+							<noServer>true</noServer>
 							<runTarget>http://localhost:8080/${rootArtifactId}-server-${dollar}{project.version}/</runTarget>
 						</configuration>
 					</plugin>

--- a/modular-webapp/src/test/resources/projects/basic/reference/client/pom.xml
+++ b/modular-webapp/src/test/resources/projects/basic/reference/client/pom.xml
@@ -151,6 +151,7 @@
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>gwt-maven-plugin</artifactId>
 						<configuration>
+							<noServer>true</noServer>
 							<runTarget>http://localhost:8080/basic-server-${project.version}/</runTarget>
 						</configuration>
 					</plugin>


### PR DESCRIPTION
Always based on your post https://groups.google.com/forum/#!msg/codehaus-mojo-gwt-maven-plugin-users/vrLAcqp5oAg/0oL-89D5m2gJ , I have supposed gwt:run should run in "noserver" mode. 
