### PR TITLE
Use ${module} as the short name of the generated GWT modules.

### DIFF
--- a/modular-requestfactory/src/main/resources/archetype-resources/client/src/main/java/__module__.gwt.xml
+++ b/modular-requestfactory/src/main/resources/archetype-resources/client/src/main/java/__module__.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "http://google-web-toolkit.googlecode.com/svn/tags/2.4.0/distro-source/core/src/gwt-module.dtd">
-<module rename-to="${rootArtifactId}">
+<module rename-to="${module}">
   <inherits name="com.google.gwt.user.User" />
   <inherits name="com.google.gwt.user.theme.clean.Clean" />
   <inherits name="com.google.web.bindery.requestfactory.RequestFactory" />

--- a/modular-requestfactory/src/main/resources/archetype-resources/client/src/main/java/__module___dev.gwt.xml
+++ b/modular-requestfactory/src/main/resources/archetype-resources/client/src/main/java/__module___dev.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "http://google-web-toolkit.googlecode.com/svn/tags/2.4.0/distro-source/core/src/gwt-module.dtd">
-<module rename-to="${rootArtifactId}">
+<module rename-to="${module}">
   <inherits name="${package}.${module}" />
 
   <set-property name="user.agent" value="safari" />

--- a/modular-requestfactory/src/main/resources/archetype-resources/server/src/main/webapp/index.html
+++ b/modular-requestfactory/src/main/resources/archetype-resources/server/src/main/webapp/index.html
@@ -23,7 +23,7 @@
     <!-- If you add any GWT meta tags, they must   -->
     <!-- be added before this line.                -->
     <!--                                           -->
-    <script src="${rootArtifactId}/${rootArtifactId}.nocache.js"></script>
+    <script src="${module}/${module}.nocache.js"></script>
   </head>
 
   <!--                                           -->

--- a/modular-requestfactory/src/test/resources/projects/basic/reference/client/src/main/java/it/pkg/Basic.gwt.xml
+++ b/modular-requestfactory/src/test/resources/projects/basic/reference/client/src/main/java/it/pkg/Basic.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "http://google-web-toolkit.googlecode.com/svn/tags/2.4.0/distro-source/core/src/gwt-module.dtd">
-<module rename-to="basic">
+<module rename-to="Basic">
   <inherits name="com.google.gwt.user.User" />
   <inherits name="com.google.gwt.user.theme.clean.Clean" />
   <inherits name="com.google.web.bindery.requestfactory.RequestFactory" />

--- a/modular-requestfactory/src/test/resources/projects/basic/reference/client/src/main/java/it/pkg/Basic_dev.gwt.xml
+++ b/modular-requestfactory/src/test/resources/projects/basic/reference/client/src/main/java/it/pkg/Basic_dev.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "http://google-web-toolkit.googlecode.com/svn/tags/2.4.0/distro-source/core/src/gwt-module.dtd">
-<module rename-to="basic">
+<module rename-to="Basic">
   <inherits name="it.pkg.Basic" />
 
   <set-property name="user.agent" value="safari" />

--- a/modular-requestfactory/src/test/resources/projects/basic/reference/server/src/main/webapp/index.html
+++ b/modular-requestfactory/src/test/resources/projects/basic/reference/server/src/main/webapp/index.html
@@ -23,7 +23,7 @@
     <!-- If you add any GWT meta tags, they must   -->
     <!-- be added before this line.                -->
     <!--                                           -->
-    <script src="basic/basic.nocache.js"></script>
+    <script src="Basic/Basic.nocache.js"></script>
   </head>
 
   <!--                                           -->

--- a/modular-webapp/src/main/resources/archetype-resources/client/src/main/java/__module__.gwt.xml
+++ b/modular-webapp/src/main/resources/archetype-resources/client/src/main/java/__module__.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "http://google-web-toolkit.googlecode.com/svn/tags/2.4.0/distro-source/core/src/gwt-module.dtd">
-<module rename-to="${rootArtifactId}">
+<module rename-to="${module}">
   <inherits name="com.google.gwt.user.User" />
   <inherits name="com.google.gwt.user.theme.clean.Clean" />
 

--- a/modular-webapp/src/main/resources/archetype-resources/client/src/main/java/__module___dev.gwt.xml
+++ b/modular-webapp/src/main/resources/archetype-resources/client/src/main/java/__module___dev.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "http://google-web-toolkit.googlecode.com/svn/tags/2.4.0/distro-source/core/src/gwt-module.dtd">
-<module rename-to="${rootArtifactId}">
+<module rename-to="${module}">
   <inherits name="${package}.${module}" />
 
   <set-property name="user.agent" value="safari" />

--- a/modular-webapp/src/main/resources/archetype-resources/server/src/main/webapp/WEB-INF/web.xml
+++ b/modular-webapp/src/main/resources/archetype-resources/server/src/main/webapp/WEB-INF/web.xml
@@ -11,7 +11,7 @@
 
   <servlet-mapping>
     <servlet-name>greetServlet</servlet-name>
-    <url-pattern>/${rootArtifactId}/greet</url-pattern>
+    <url-pattern>/${module}/greet</url-pattern>
   </servlet-mapping>
 
 	<!-- Default page to serve -->

--- a/modular-webapp/src/main/resources/archetype-resources/server/src/main/webapp/index.html
+++ b/modular-webapp/src/main/resources/archetype-resources/server/src/main/webapp/index.html
@@ -23,7 +23,7 @@
     <!-- If you add any GWT meta tags, they must   -->
     <!-- be added before this line.                -->
     <!--                                           -->
-    <script src="${rootArtifactId}/${rootArtifactId}.nocache.js"></script>
+    <script src="${module}/${module}.nocache.js"></script>
   </head>
 
   <!--                                           -->

--- a/modular-webapp/src/test/resources/projects/basic/reference/client/src/main/java/it/pkg/Basic.gwt.xml
+++ b/modular-webapp/src/test/resources/projects/basic/reference/client/src/main/java/it/pkg/Basic.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "http://google-web-toolkit.googlecode.com/svn/tags/2.4.0/distro-source/core/src/gwt-module.dtd">
-<module rename-to="basic">
+<module rename-to="Basic">
   <inherits name="com.google.gwt.user.User" />
   <inherits name="com.google.gwt.user.theme.clean.Clean" />
 

--- a/modular-webapp/src/test/resources/projects/basic/reference/client/src/main/java/it/pkg/Basic_dev.gwt.xml
+++ b/modular-webapp/src/test/resources/projects/basic/reference/client/src/main/java/it/pkg/Basic_dev.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "http://google-web-toolkit.googlecode.com/svn/tags/2.4.0/distro-source/core/src/gwt-module.dtd">
-<module rename-to="basic">
+<module rename-to="Basic">
   <inherits name="it.pkg.Basic" />
 
   <set-property name="user.agent" value="safari" />

--- a/modular-webapp/src/test/resources/projects/basic/reference/server/src/main/webapp/WEB-INF/web.xml
+++ b/modular-webapp/src/test/resources/projects/basic/reference/server/src/main/webapp/WEB-INF/web.xml
@@ -11,7 +11,7 @@
 
   <servlet-mapping>
     <servlet-name>greetServlet</servlet-name>
-    <url-pattern>/basic/greet</url-pattern>
+    <url-pattern>/Basic/greet</url-pattern>
   </servlet-mapping>
 
 	<!-- Default page to serve -->

--- a/modular-webapp/src/test/resources/projects/basic/reference/server/src/main/webapp/index.html
+++ b/modular-webapp/src/test/resources/projects/basic/reference/server/src/main/webapp/index.html
@@ -23,7 +23,7 @@
     <!-- If you add any GWT meta tags, they must   -->
     <!-- be added before this line.                -->
     <!--                                           -->
-    <script src="basic/basic.nocache.js"></script>
+    <script src="Basic/Basic.nocache.js"></script>
   </head>
 
   <!--                                           -->


### PR DESCRIPTION
Found that the build will fail if the artifactId contains a dash, which is very common in the maven world. 
I changed the rename-to attribute to ${module} to avoid this problem, mainly because we use the ${module} property to name the EntryPoint or the application, thus it has to comply with JAVA naming conventions.
