### PR TITLE
fix server start by adding jetty-maven-plugin as build plugin

### DIFF
--- a/guice-rf-activities/src/main/resources/archetype-resources/__rootArtifactId__-server/pom.xml
+++ b/guice-rf-activities/src/main/resources/archetype-resources/__rootArtifactId__-server/pom.xml
@@ -78,6 +78,10 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.mortbay.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/modular-requestfactory/src/main/resources/archetype-resources/__rootArtifactId__-server/pom.xml
+++ b/modular-requestfactory/src/main/resources/archetype-resources/__rootArtifactId__-server/pom.xml
@@ -66,6 +66,10 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.mortbay.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/modular-requestfactory/src/test/resources/projects/basic-rf/reference/basic-rf-server/pom.xml
+++ b/modular-requestfactory/src/test/resources/projects/basic-rf/reference/basic-rf-server/pom.xml
@@ -65,6 +65,10 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.mortbay.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/modular-webapp/src/main/resources/archetype-resources/__rootArtifactId__-server/pom.xml
+++ b/modular-webapp/src/main/resources/archetype-resources/__rootArtifactId__-server/pom.xml
@@ -35,6 +35,15 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.mortbay.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>dev</id>

--- a/modular-webapp/src/test/resources/projects/basic-webapp/reference/basic-webapp-server/pom.xml
+++ b/modular-webapp/src/test/resources/projects/basic-webapp/reference/basic-webapp-server/pom.xml
@@ -34,6 +34,15 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.mortbay.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>dev</id>


### PR DESCRIPTION
`jetty-maven-plugin` was only present in `pluginManagement` parts. When launching `cd *-server && mvn jetty:start -Ddev`, the following error occured :

```
[INFO] ------------------------------------------------------------------------
[ERROR] BUILD ERROR
[INFO] ------------------------------------------------------------------------
[INFO] The plugin 'org.apache.maven.plugins:maven-jetty-plugin' does not exist or no valid version could be found
```

I hesitated between adding `jetty-maven-plugin` as general build plugin or only in `dev` profile. I finally choose the first option which additionnally provides a way to start server in a mode where `server` uses `*-shared.jar` and `*-client.war` dependencies previously installed with a `mvn clean install` in root directory.

What do you think?
