### PR TITLE
Use the gwt-version property for the dtd declaration inside gwt.xml files

### DIFF
--- a/guice-rf-activities/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/java/__module__.gwt.xml
+++ b/guice-rf-activities/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/java/__module__.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "http://google-web-toolkit.googlecode.com/svn/tags/2.4.0/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit ${gwt-version}//EN" "http://google-web-toolkit.googlecode.com/svn/tags/${gwt-version}/distro-source/core/src/gwt-module.dtd">
 <module rename-to="${module-short-name}">
   <inherits name="com.google.common.base.Base" />
   <inherits name="com.google.gwt.activity.Activity" />

--- a/guice-rf-activities/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/java/__module___dev.gwt.xml
+++ b/guice-rf-activities/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/java/__module___dev.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "http://google-web-toolkit.googlecode.com/svn/tags/2.4.0/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit ${gwt-version}//EN" "http://google-web-toolkit.googlecode.com/svn/tags/${gwt-version}/distro-source/core/src/gwt-module.dtd">
 <module rename-to="${module-short-name}">
   <inherits name="${package}.${module}" />
 

--- a/modular-requestfactory/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/java/__module__.gwt.xml
+++ b/modular-requestfactory/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/java/__module__.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "http://google-web-toolkit.googlecode.com/svn/tags/2.4.0/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit ${gwt-version}//EN" "http://google-web-toolkit.googlecode.com/svn/tags/${gwt-version}/distro-source/core/src/gwt-module.dtd">
 <module rename-to="${module-short-name}">
   <inherits name="com.google.gwt.user.User" />
   <inherits name="com.google.gwt.user.theme.clean.Clean" />

--- a/modular-requestfactory/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/java/__module___dev.gwt.xml
+++ b/modular-requestfactory/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/java/__module___dev.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "http://google-web-toolkit.googlecode.com/svn/tags/2.4.0/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit ${gwt-version}//EN" "http://google-web-toolkit.googlecode.com/svn/tags/${gwt-version}/distro-source/core/src/gwt-module.dtd">
 <module rename-to="${module-short-name}">
   <inherits name="${package}.${module}" />
 

--- a/modular-webapp/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/java/__module__.gwt.xml
+++ b/modular-webapp/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/java/__module__.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "http://google-web-toolkit.googlecode.com/svn/tags/2.4.0/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit ${gwt-version}//EN" "http://google-web-toolkit.googlecode.com/svn/tags/${gwt-version}/distro-source/core/src/gwt-module.dtd">
 <module rename-to="${module-short-name}">
   <inherits name="com.google.gwt.user.User" />
   <inherits name="com.google.gwt.user.theme.clean.Clean" />

--- a/modular-webapp/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/java/__module___dev.gwt.xml
+++ b/modular-webapp/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/java/__module___dev.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "http://google-web-toolkit.googlecode.com/svn/tags/2.4.0/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit ${gwt-version}//EN" "http://google-web-toolkit.googlecode.com/svn/tags/${gwt-version}/distro-source/core/src/gwt-module.dtd">
 <module rename-to="${module-short-name}">
   <inherits name="${package}.${module}" />
 


### PR DESCRIPTION
Hello, 

Here is a small patch to use the gwt-version property for the dtd instead of the hard-coded 2.4.0 version.
