### PR TITLE
"-workDir" makes gwt-maven-archetypes currently unusable out of the box on Mac

### DIFF
--- a/guice-rf-activities/src/main/resources/archetype-resources/pom.xml
+++ b/guice-rf-activities/src/main/resources/archetype-resources/pom.xml
@@ -117,7 +117,9 @@
             <deploy>${dollar}{project.build.directory}/gwtc/extra</deploy>
             <extra>${dollar}{project.build.directory}/gwtc/extra</extra>
             <gen>${dollar}{project.build.directory}/gwtc/gen</gen>
+            <!-- There's an issue on Mac: see http://code.google.com/p/google-web-toolkit/issues/detail?id=7474
             <workDir>${dollar}{project.build.directory}/gwtc/work</workDir>
+            -->
           </configuration>
           <executions>
             <execution>

--- a/modular-requestfactory/src/main/resources/archetype-resources/pom.xml
+++ b/modular-requestfactory/src/main/resources/archetype-resources/pom.xml
@@ -82,7 +82,9 @@
             <deploy>${dollar}{project.build.directory}/gwtc/extra</deploy>
             <extra>${dollar}{project.build.directory}/gwtc/extra</extra>
             <gen>${dollar}{project.build.directory}/gwtc/gen</gen>
+            <!-- There's an issue on Mac: see http://code.google.com/p/google-web-toolkit/issues/detail?id=7474
             <workDir>${dollar}{project.build.directory}/gwtc/work</workDir>
+            -->
           </configuration>
           <executions>
             <execution>

--- a/modular-requestfactory/src/test/resources/projects/basic-rf/reference/pom.xml
+++ b/modular-requestfactory/src/test/resources/projects/basic-rf/reference/pom.xml
@@ -81,7 +81,9 @@
             <deploy>${project.build.directory}/gwtc/extra</deploy>
             <extra>${project.build.directory}/gwtc/extra</extra>
             <gen>${project.build.directory}/gwtc/gen</gen>
+            <!-- There's an issue on Mac: see http://code.google.com/p/google-web-toolkit/issues/detail?id=7474
             <workDir>${project.build.directory}/gwtc/work</workDir>
+            -->
           </configuration>
           <executions>
             <execution>

--- a/modular-webapp/src/main/resources/archetype-resources/pom.xml
+++ b/modular-webapp/src/main/resources/archetype-resources/pom.xml
@@ -71,7 +71,9 @@
             <deploy>${dollar}{project.build.directory}/gwtc/extra</deploy>
             <extra>${dollar}{project.build.directory}/gwtc/extra</extra>
             <gen>${dollar}{project.build.directory}/gwtc/gen</gen>
+            <!-- There's an issue on Mac: see http://code.google.com/p/google-web-toolkit/issues/detail?id=7474
             <workDir>${dollar}{project.build.directory}/gwtc/work</workDir>
+            -->
           </configuration>
           <executions>
             <execution>

--- a/modular-webapp/src/test/resources/projects/basic-webapp/reference/pom.xml
+++ b/modular-webapp/src/test/resources/projects/basic-webapp/reference/pom.xml
@@ -70,7 +70,9 @@
             <deploy>${project.build.directory}/gwtc/extra</deploy>
             <extra>${project.build.directory}/gwtc/extra</extra>
             <gen>${project.build.directory}/gwtc/gen</gen>
+            <!-- There's an issue on Mac: see http://code.google.com/p/google-web-toolkit/issues/detail?id=7474
             <workDir>${project.build.directory}/gwtc/work</workDir>
+            -->
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
Because of the GWT issue http://code.google.com/p/google-web-toolkit/issues/detail?id=7474, it's currently necessary on Macs to either
- disable the unitCache or
- remove the -workDir setting

I would love to see the archetypes work for every environment out of the box. Would it be possible to either remove the -workDir setting, or find some workaround, or at least document it very clearly (the issue was really hard to track down).
