### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ How to use
 
 ### Generate a project
 
-    mvn archetype:generate \
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate \
        -DarchetypeCatalog=https://oss.sonatype.org/content/repositories/snapshots/ \
        -DarchetypeGroupId=net.ltgt.gwt.archetypes \
        -DarchetypeArtifactId=<artifactId> \


### PR DESCRIPTION
- lazy way to avoid "archetypeCatalog 'https:/oss.sonatype.org/content/repositories/snapshots/' is not supported anymore. Please read the plugin documentation for details." with latest Maven 3.5.0 ;-)