### PR TITLE
Drop support for IE10

### DIFF
--- a/dagger-guice-rf-activities/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/module.gwt.xml
+++ b/dagger-guice-rf-activities/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/module.gwt.xml
@@ -11,5 +11,5 @@
   <entry-point class="${package}.${module}" />
 
   <!-- Only support recent browsers -->
-  <set-property name="user.agent" value="ie10,gecko1_8,safari" />
+  <set-property name="user.agent" value="gecko1_8,safari" />
 </module>

--- a/modular-requestfactory/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/module.gwt.xml
+++ b/modular-requestfactory/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/module.gwt.xml
@@ -9,5 +9,5 @@
   <entry-point class="${package}.${module}" />
 
   <!-- Only support recent browsers -->
-  <set-property name="user.agent" value="ie10,gecko1_8,safari" />
+  <set-property name="user.agent" value="gecko1_8,safari" />
 </module>

--- a/modular-requestfactory/src/test/resources/projects/basic-rf/reference/basic-rf-client/src/main/module.gwt.xml
+++ b/modular-requestfactory/src/test/resources/projects/basic-rf/reference/basic-rf-client/src/main/module.gwt.xml
@@ -9,5 +9,5 @@
   <entry-point class="it.pkg.Basic" />
 
   <!-- Only support recent browsers -->
-  <set-property name="user.agent" value="ie10,gecko1_8,safari" />
+  <set-property name="user.agent" value="gecko1_8,safari" />
 </module>

--- a/modular-webapp/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/module.gwt.xml
+++ b/modular-webapp/src/main/resources/archetype-resources/__rootArtifactId__-client/src/main/module.gwt.xml
@@ -8,5 +8,5 @@
   <entry-point class="${package}.${module}" />
 
   <!-- Only support recent browsers -->
-  <set-property name="user.agent" value="ie10,gecko1_8,safari" />
+  <set-property name="user.agent" value="gecko1_8,safari" />
 </module>

--- a/modular-webapp/src/test/resources/projects/basic-webapp/reference/basic-webapp-client/src/main/module.gwt.xml
+++ b/modular-webapp/src/test/resources/projects/basic-webapp/reference/basic-webapp-client/src/main/module.gwt.xml
@@ -8,5 +8,5 @@
   <entry-point class="it.pkg.Basic" />
 
   <!-- Only support recent browsers -->
-  <set-property name="user.agent" value="ie10,gecko1_8,safari" />
+  <set-property name="user.agent" value="gecko1_8,safari" />
 </module>


### PR DESCRIPTION
IE10 has long passed its end-of-life, and will not be supported by GWT
2.10.

https://docs.microsoft.com/en-us/lifecycle/announcements/internet-explorer-10-end-of-support