### PR TITLE
Adding notes for Windows Powershell Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ How to use
 
 ### Generate a project
 
+Note:  Windows Powershell Users - make sure to quote the parameters. ie.  mvn archetype:generate "-DarchetypeGroupId=net.ltgt.gwt.archetypes" "-DarchetypeVersion=LATEST" "-DarchetypeArtifactId=modular-webapp"  See https://stackoverflow.com/questions/17385864/why-does-not-archetypegenerate-with-parameters-work-for-me
+
+
     mvn archetype:generate \
        -DarchetypeGroupId=net.ltgt.gwt.archetypes \
        -DarchetypeVersion=LATEST \


### PR DESCRIPTION
PowerShell requires quotes around the parameters to properly create the project.  (otherwise the command fails mentioning that a pom needs to exist in the directory)